### PR TITLE
refactor(test): rename test to describe behavior instead of fix history

### DIFF
--- a/src/test/java/edu/gwu/csci6212/MinimumStepsChessKnightTest.java
+++ b/src/test/java/edu/gwu/csci6212/MinimumStepsChessKnightTest.java
@@ -32,7 +32,7 @@ class MinimumStepsChessKnightTest {
     }
 
     @Test
-    void reachesCornerAtOriginAfterFix() {
+    void findsFourStepPathFromBoardCorner() {
         assertEquals(4, MinimumStepsChessKnight.minSteps(8, 0, 0, 1, 1));
     }
 }


### PR DESCRIPTION
## Summary

- Renames `reachesCornerAtOriginAfterFix` → `findsFourStepPathFromBoardCorner` in `MinimumStepsChessKnightTest`
- Aligns with the existing naming style (`findsTwoStepPath`, `findsThreeStepPath`, `findsFourStepPath`)
- Removes the "AfterFix" suffix, which leaks implementation history rather than describing the tested behavior

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)