### PR TITLE
fix: validate non-negative coin values in CoinPickingGame constructor

### DIFF
--- a/src/main/java/edu/gwu/csci6212/CoinPickingGame.java
+++ b/src/main/java/edu/gwu/csci6212/CoinPickingGame.java
@@ -11,6 +11,12 @@ public final class CoinPickingGame {
             throw new IllegalArgumentException(
                     "coin count must be a positive even number, was " + coins.length);
         }
+        for (int coin : coins) {
+            if (coin < 0) {
+                throw new IllegalArgumentException(
+                        "all coin values must be non-negative, found " + coin);
+            }
+        }
         this.coins = coins.clone();
         this.memo = new Scores[coins.length][coins.length];
     }

--- a/src/test/java/edu/gwu/csci6212/CoinPickingGameTest.java
+++ b/src/test/java/edu/gwu/csci6212/CoinPickingGameTest.java
@@ -21,6 +21,12 @@ class CoinPickingGameTest {
     }
 
     @Test
+    void rejectsNegativeCoinValue() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new CoinPickingGame(new int[] { 1, -1, 1, 1 }));
+    }
+
+    @Test
     void acceptsEvenNumberOfCoins() {
         new CoinPickingGame(new int[] { 1, 1, 1, 1 });
     }


### PR DESCRIPTION
## Summary

- Adds a validation loop in `CoinPickingGame` constructor that throws `IllegalArgumentException` for any negative coin value
- Adds `rejectsNegativeCoinValue` test in `CoinPickingGameTest`

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)