### PR TITLE
ci: add GitHub Actions workflow to run unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: temurin
+          cache: maven
+      - run: mvn test


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` that runs `mvn test` on every push to `master` and on every pull request
- Uses Java 21 (Temurin) to match the `maven.compiler.release` target in `pom.xml`
- Caches the Maven local repository to speed up subsequent runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)