### PR TITLE
refactor: replace BFS queue state with DP distance table in MinimumStepsChessKnight

### DIFF
--- a/src/main/java/edu/gwu/csci6212/MinimumStepsChessKnight.java
+++ b/src/main/java/edu/gwu/csci6212/MinimumStepsChessKnight.java
@@ -1,7 +1,8 @@
 package edu.gwu.csci6212;
 
 import java.util.ArrayDeque;
-import java.util.Deque;
+import java.util.Arrays;
+import java.util.Queue;
 
 public final class MinimumStepsChessKnight {
     private static final int[][] KNIGHT_MOVES = {
@@ -9,37 +10,34 @@ public final class MinimumStepsChessKnight {
             { -2, 1 }, { -2, -1 }, { -1,  2 }, { -1, -2 }
     };
 
-    private record Position(int x, int y, int steps) {}
-
     private MinimumStepsChessKnight() {}
 
     public static int minSteps(int boardSize, int startX, int startY, int goalX, int goalY) {
         if (!inBounds(startX, startY, boardSize) || !inBounds(goalX, goalY, boardSize)) {
             return -1;
         }
-        if (startX == goalX && startY == goalY) {
-            return 0;
-        }
 
-        boolean[][] visited = new boolean[boardSize][boardSize];
-        visited[startX][startY] = true;
+        int[][] dist = new int[boardSize][boardSize];
+        for (int[] row : dist) Arrays.fill(row, -1);
+        dist[startX][startY] = 0;
 
-        Deque<Position> queue = new ArrayDeque<>();
-        queue.add(new Position(startX, startY, 0));
+        // Queue drives fill order; dist[][] is the DP state.
+        Queue<int[]> queue = new ArrayDeque<>();
+        queue.add(new int[]{startX, startY});
 
         while (!queue.isEmpty()) {
-            Position curr = queue.remove();
+            int[] curr = queue.remove();
+            int cx = curr[0], cy = curr[1];
             for (int[] move : KNIGHT_MOVES) {
-                int nx = curr.x() + move[0];
-                int ny = curr.y() + move[1];
-                if (!inBounds(nx, ny, boardSize) || visited[nx][ny]) continue;
-                int nextSteps = curr.steps() + 1;
-                if (nx == goalX && ny == goalY) return nextSteps;
-                visited[nx][ny] = true;
-                queue.add(new Position(nx, ny, nextSteps));
+                int nx = cx + move[0];
+                int ny = cy + move[1];
+                if (!inBounds(nx, ny, boardSize) || dist[nx][ny] != -1) continue;
+                dist[nx][ny] = dist[cx][cy] + 1;
+                queue.add(new int[]{nx, ny});
             }
         }
-        return -1;
+
+        return dist[goalX][goalY];
     }
 
     private static boolean inBounds(int x, int y, int size) {

--- a/src/test/java/edu/gwu/csci6212/MinimumStepsChessKnightTest.java
+++ b/src/test/java/edu/gwu/csci6212/MinimumStepsChessKnightTest.java
@@ -35,4 +35,30 @@ class MinimumStepsChessKnightTest {
     void findsFourStepPathFromBoardCorner() {
         assertEquals(4, MinimumStepsChessKnight.minSteps(8, 0, 0, 1, 1));
     }
+
+    @Test
+    void returnsMinusOneWhenGoalOutOfBounds() {
+        assertEquals(-1, MinimumStepsChessKnight.minSteps(7, 1, 1, 7, 5));
+    }
+
+    @Test
+    void findsOneStepPath() {
+        // (0,0) -> (1,2) is a single knight move
+        assertEquals(1, MinimumStepsChessKnight.minSteps(7, 0, 0, 1, 2));
+    }
+
+    @Test
+    void returnsMinusOneWhenGoalUnreachable() {
+        // On a 2x2 board every knight move leaves the board, so no cell other than
+        // the start is reachable; the dist table entry stays -1.
+        assertEquals(-1, MinimumStepsChessKnight.minSteps(2, 0, 0, 1, 1));
+    }
+
+    @Test
+    void pathLengthIsSymmetric() {
+        // The minimum steps from A to B must equal the minimum steps from B to A.
+        int forward = MinimumStepsChessKnight.minSteps(7, 4, 5, 1, 1);
+        int reverse = MinimumStepsChessKnight.minSteps(7, 1, 1, 4, 5);
+        assertEquals(forward, reverse);
+    }
 }


### PR DESCRIPTION
## Summary

The previous implementation tracked steps inside the queue element (`Position` record), making the queue the source of truth — a pure BFS. This PR restructures it so the `dist[][]` table is the primary DP state:

- Allocate `int[][] dist` initialized to `-1`; set `dist[startX][startY] = 0`
- The recurrence `dist[nx][ny] = dist[cx][cy] + 1` is the explicit DP relaxation step
- The queue only drives fill order; it carries coordinates, not distance
- Removed the `Position` record and the early-exit `start == goal` check (handled naturally by `dist[startX][startY] = 0`)
- All existing tests pass unchanged

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)