### PR TITLE
refactor: make CoinPickingGame a static utility

### DIFF
--- a/src/main/java/edu/gwu/csci6212/CoinPickingGame.java
+++ b/src/main/java/edu/gwu/csci6212/CoinPickingGame.java
@@ -1,12 +1,11 @@
 package edu.gwu.csci6212;
 
 public final class CoinPickingGame {
-    private final int[] coins;
-    private final Scores[][] memo;
-
     private record Scores(int playerOne, int playerTwo) {}
 
-    public CoinPickingGame(int[] coins) {
+    private CoinPickingGame() {}
+
+    public static int maxScore(int[] coins) {
         if (coins.length == 0 || coins.length % 2 != 0) {
             throw new IllegalArgumentException(
                     "coin count must be a positive even number, was " + coins.length);
@@ -17,28 +16,24 @@ public final class CoinPickingGame {
                         "all coin values must be non-negative, found " + coin);
             }
         }
-        this.coins = coins.clone();
-        this.memo = new Scores[coins.length][coins.length];
-    }
-
-    public int play() {
-        fillMemo();
+        Scores[][] memo = new Scores[coins.length][coins.length];
+        fillMemo(coins, memo);
         return memo[coins.length - 1][0].playerOne();
     }
 
-    private void fillMemo() {
+    private static void fillMemo(int[] coins, Scores[][] memo) {
         for (int i = 0; i < coins.length; i++) {
             memo[i][i] = new Scores(coins[i], 0);
         }
         for (int span = 1; span < coins.length; span++) {
             for (int right = span; right < coins.length; right++) {
                 int left = right - span;
-                memo[right][left] = bestChoice(right, left);
+                memo[right][left] = bestChoice(coins, memo, right, left);
             }
         }
     }
 
-    private Scores bestChoice(int right, int left) {
+    private static Scores bestChoice(int[] coins, Scores[][] memo, int right, int left) {
         Scores takeLeft = new Scores(
                 memo[right][left + 1].playerTwo() + coins[left],
                 memo[right][left + 1].playerOne());

--- a/src/test/java/edu/gwu/csci6212/CoinPickingGameTest.java
+++ b/src/test/java/edu/gwu/csci6212/CoinPickingGameTest.java
@@ -2,7 +2,6 @@ package edu.gwu.csci6212;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
@@ -11,41 +10,33 @@ class CoinPickingGameTest {
     @Test
     void rejectsOddNumberOfCoins() {
         assertThrows(IllegalArgumentException.class,
-                () -> new CoinPickingGame(new int[] { 1, 1, 1 }));
+                () -> CoinPickingGame.maxScore(new int[] { 1, 1, 1 }));
     }
 
     @Test
     void rejectsZeroCoins() {
         assertThrows(IllegalArgumentException.class,
-                () -> new CoinPickingGame(new int[] {}));
+                () -> CoinPickingGame.maxScore(new int[] {}));
     }
 
     @Test
     void rejectsNegativeCoinValue() {
         assertThrows(IllegalArgumentException.class,
-                () -> new CoinPickingGame(new int[] { 1, -1, 1, 1 }));
+                () -> CoinPickingGame.maxScore(new int[] { 1, -1, 1, 1 }));
     }
 
     @Test
-    void acceptsEvenNumberOfCoins() {
-        new CoinPickingGame(new int[] { 1, 1, 1, 1 });
-    }
-
-    @Test
-    void playReturnsPositiveResult() {
-        CoinPickingGame game = new CoinPickingGame(new int[] { 1, 1, 1, 1 });
-        assertTrue(game.play() > 0);
+    void twoEqualCoinsReturnsEitherValue() {
+        assertEquals(1, CoinPickingGame.maxScore(new int[] { 1, 1 }));
     }
 
     @Test
     void optimizesWhenGreedyIsSufficient() {
-        CoinPickingGame game = new CoinPickingGame(new int[] { 5, 3, 7, 10 });
-        assertEquals(15, game.play());
+        assertEquals(15, CoinPickingGame.maxScore(new int[] { 5, 3, 7, 10 }));
     }
 
     @Test
     void optimizesWhenGreedyIsInsufficient() {
-        CoinPickingGame game = new CoinPickingGame(new int[] { 8, 15, 3, 7 });
-        assertEquals(22, game.play());
+        assertEquals(22, CoinPickingGame.maxScore(new int[] { 8, 15, 3, 7 }));
     }
 }


### PR DESCRIPTION
## Summary

- Replaces `new CoinPickingGame(coins).play()` with `CoinPickingGame.maxScore(int[] coins)` — a static method consistent with `MinimumStepsChessKnight.minSteps()`
- `memo` and `coins` move from instance fields to local variables; `fillMemo` and `bestChoice` become `static`
- Private constructor added to prevent instantiation
- Drops the `acceptsEvenNumberOfCoins` test (only verified construction — no longer meaningful)
- Replaces the weak `playReturnsPositiveResult` (`assertTrue(> 0)`) with `twoEqualCoinsReturnsEitherValue` (`assertEquals(1, ...)`) — a specific assertion on the minimal two-coin case

🤖 Generated with [Claude Code](https://claude.com/claude-code)