### PR TITLE
fix: throw IllegalArgumentException for non-positive boardSize in MinimumStepsChessKnight

### DIFF
--- a/src/main/java/edu/gwu/csci6212/MinimumStepsChessKnight.java
+++ b/src/main/java/edu/gwu/csci6212/MinimumStepsChessKnight.java
@@ -13,6 +13,10 @@ public final class MinimumStepsChessKnight {
     private MinimumStepsChessKnight() {}
 
     public static int minSteps(int boardSize, int startX, int startY, int goalX, int goalY) {
+        if (boardSize <= 0) {
+            throw new IllegalArgumentException(
+                    "boardSize must be a positive integer, was " + boardSize);
+        }
         if (!inBounds(startX, startY, boardSize) || !inBounds(goalX, goalY, boardSize)) {
             return -1;
         }

--- a/src/test/java/edu/gwu/csci6212/MinimumStepsChessKnightTest.java
+++ b/src/test/java/edu/gwu/csci6212/MinimumStepsChessKnightTest.java
@@ -1,10 +1,23 @@
 package edu.gwu.csci6212;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
 class MinimumStepsChessKnightTest {
+
+    @Test
+    void rejectsZeroBoardSize() {
+        assertThrows(IllegalArgumentException.class,
+                () -> MinimumStepsChessKnight.minSteps(0, 0, 0, 0, 0));
+    }
+
+    @Test
+    void rejectsNegativeBoardSize() {
+        assertThrows(IllegalArgumentException.class,
+                () -> MinimumStepsChessKnight.minSteps(-1, 0, 0, 0, 0));
+    }
 
     @Test
     void returnsMinusOneWhenStartOutOfBounds() {


### PR DESCRIPTION
## Summary

- Adds an explicit `boardSize <= 0` guard at the top of `minSteps()`, throwing `IllegalArgumentException` with a descriptive message — consistent with the validation pattern in `CoinPickingGame`
- Previously `minSteps(0, 0, 0, 0, 0)` silently returned `-1` because `inBounds` always returned false with a zero-size board
- Adds `rejectsZeroBoardSize` and `rejectsNegativeBoardSize` tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)