### PR TITLE
docs: add CI status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Dynamic Programming HW
 
+[![CI](https://github.com/bushidocodes/dynamic-programming-katas/actions/workflows/ci.yml/badge.svg)](https://github.com/bushidocodes/dynamic-programming-katas/actions/workflows/ci.yml)
+
 by [Alvaro Albero Gran](https://github.com/albero94), [Sean McBride](https://github.com/bushidocodes), and [Devyani Raghuwanshi](https://github.com/Devyani1904)
 
 ## About


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions CI status badge to the README immediately after the h1 title
- Badge links to the `ci.yml` workflow run history on GitHub Actions

## Test plan
- [ ] Verify the badge renders correctly on the PR preview
- [ ] Confirm the badge reflects the current CI status after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)