### PR TITLE
feat: implement HouseRobbing DP solution

### DIFF
--- a/src/main/java/edu/gwu/csci6212/HouseRobbing.java
+++ b/src/main/java/edu/gwu/csci6212/HouseRobbing.java
@@ -1,0 +1,56 @@
+package edu.gwu.csci6212;
+
+public final class HouseRobbing {
+    private HouseRobbing() {}
+
+    /**
+     * Returns the maximum loot that can be collected from houses arranged in a circle,
+     * where no two adjacent houses may be robbed.
+     *
+     * @param houses non-null, non-empty array of non-negative house values
+     * @return maximum loot collectable without triggering any alarm
+     * @throws IllegalArgumentException if houses is null, empty, or contains a negative value
+     */
+    public static int maxLoot(int[] houses) {
+        if (houses == null || houses.length == 0) {
+            throw new IllegalArgumentException(
+                    "houses must be a non-null, non-empty array");
+        }
+        for (int value : houses) {
+            if (value < 0) {
+                throw new IllegalArgumentException(
+                        "all house values must be non-negative, found " + value);
+            }
+        }
+
+        if (houses.length == 1) {
+            return houses[0];
+        }
+
+        // Because house[0] and house[n-1] are adjacent (circular), split into two
+        // linear subproblems and return the better result.
+        return Math.max(
+                linearMaxLoot(houses, 0, houses.length - 2),
+                linearMaxLoot(houses, 1, houses.length - 1));
+    }
+
+    /**
+     * Solves the non-circular house-robber DP over houses[from..to] (inclusive).
+     */
+    private static int linearMaxLoot(int[] houses, int from, int to) {
+        if (from == to) {
+            return houses[from];
+        }
+
+        int prev2 = houses[from];
+        int prev1 = Math.max(houses[from], houses[from + 1]);
+
+        for (int i = from + 2; i <= to; i++) {
+            int curr = Math.max(prev1, prev2 + houses[i]);
+            prev2 = prev1;
+            prev1 = curr;
+        }
+
+        return prev1;
+    }
+}

--- a/src/test/java/edu/gwu/csci6212/HouseRobbingTest.java
+++ b/src/test/java/edu/gwu/csci6212/HouseRobbingTest.java
@@ -1,0 +1,89 @@
+package edu.gwu.csci6212;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class HouseRobbingTest {
+
+    @Test
+    void rejectsNullArray() {
+        assertThrows(IllegalArgumentException.class,
+                () -> HouseRobbing.maxLoot(null));
+    }
+
+    @Test
+    void rejectsEmptyArray() {
+        assertThrows(IllegalArgumentException.class,
+                () -> HouseRobbing.maxLoot(new int[]{}));
+    }
+
+    @Test
+    void rejectsNegativeHouseValue() {
+        assertThrows(IllegalArgumentException.class,
+                () -> HouseRobbing.maxLoot(new int[]{3, -1, 5}));
+    }
+
+    @Test
+    void singleHouseReturnsThatValue() {
+        assertEquals(42, HouseRobbing.maxLoot(new int[]{42}));
+    }
+
+    @Test
+    void twoHousesReturnsTheLarger() {
+        assertEquals(7, HouseRobbing.maxLoot(new int[]{3, 7}));
+    }
+
+    @Test
+    void twoIdenticalHousesReturnsThatValue() {
+        assertEquals(5, HouseRobbing.maxLoot(new int[]{5, 5}));
+    }
+
+    // Assignment example 1: [2, 3, 2] -> 3
+    // Robbing house 1 (value 3) is the best; houses 0 and 2 are adjacent across the circle.
+    @Test
+    void assignmentExampleThreeHouses() {
+        assertEquals(3, HouseRobbing.maxLoot(new int[]{2, 3, 2}));
+    }
+
+    // Assignment example 2: [1, 2, 3, 1] -> 4
+    // Rob houses 0 and 2: 1 + 3 = 4.
+    @Test
+    void assignmentExampleFourHouses() {
+        assertEquals(4, HouseRobbing.maxLoot(new int[]{1, 2, 3, 1}));
+    }
+
+    // Greedy "always take the largest adjacent end" would pick 9 first, then be blocked,
+    // and end up with 9. The DP correctly picks 5 + 4 + 1 = 10 instead.
+    // Array: [1, 5, 4, 2, 9] (circular)
+    //   Subproblem 1 [1,5,4,2]: dp -> max(1+4, 5+2) = max(5,7) = 7
+    //   Subproblem 2 [5,4,2,9]: dp -> max(5+2, 4+9) = max(7,13) = 13
+    //   Answer: 13 (rob houses at indices 1,3,4 => 5+2+9 is invalid; correctly: indices 1 and 4 => 5+9 blocked; indices 0,2 unavail in sub2; let's verify)
+    // Actually for [5,4,2,9]: best is rob index3=9 and index0=5 => 14? No, sub2 is houses[1..4]=[5,4,2,9]
+    //   i=0: prev2=5, prev1=max(5,4)=5
+    //   i=2 (value 2): curr=max(5, 5+2)=7, prev2=5, prev1=7
+    //   i=3 (value 9): curr=max(7, 5+9)=14, prev2=7, prev1=14
+    // Sub1 [1,5,4,2]: i=0: prev2=1,prev1=5; i=2(4): curr=max(5,1+4)=5,prev2=5,prev1=5; i=3(2): curr=max(5,5+2)=7
+    // Answer: max(7, 14) = 14
+    // [6, 1, 9, 1, 6] (circular): the obvious greedy of "start from the largest (9)
+    // then take its non-adjacent neighbours" yields 9 + 6 = 15 only if you happen to
+    // skip the circular constraint; a greedy that just takes every other house left-to-right
+    // gets 6 + 9 + 6 = 21 which is invalid (idx 0 and idx 4 are adjacent).
+    // The DP correctly produces 15: rob idx 0 and idx 2 (6+9) via sub-problem [6,1,9,1].
+    @Test
+    void greedyFailCase() {
+        assertEquals(15, HouseRobbing.maxLoot(new int[]{6, 1, 9, 1, 6}));
+    }
+
+    @Test
+    void allZeroesReturnsZero() {
+        assertEquals(0, HouseRobbing.maxLoot(new int[]{0, 0, 0, 0}));
+    }
+
+    // [2, 7, 9, 3, 1] (circular): optimal is rob idx 0 and idx 2: 2 + 9 = 11.
+    @Test
+    void largerCircularCase() {
+        assertEquals(11, HouseRobbing.maxLoot(new int[]{2, 7, 9, 3, 1}));
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `HouseRobbing`, a final static utility class in `edu.gwu.csci6212`, implementing the circular house-robber DP problem
- Reduces the circular problem to two linear subproblems (exclude last house / exclude first house), each solved with the standard `dp[i] = max(dp[i-1], dp[i-2] + houses[i])` recurrence
- Validates input (null, empty, negative values) with `IllegalArgumentException`, matching the style of `CoinPickingGame` and `MinimumStepsChessKnight`

## Test plan

- [x] Rejects null array
- [x] Rejects empty array
- [x] Rejects negative house value
- [x] Single house returns its value
- [x] Two houses returns the larger
- [x] Two identical houses returns that value
- [x] Assignment example 1: `[2,3,2]` → `3`
- [x] Assignment example 2: `[1,2,3,1]` → `4`
- [x] Greedy-fail case: `[6,1,9,1,6]` → `15` (naive every-other greedy would wrongly claim `6+9+6=21`, violating the circular adjacency)
- [x] All-zeroes array returns `0`
- [x] Larger circular case: `[2,7,9,3,1]` → `11`

🤖 Generated with [Claude Code](https://claude.com/claude-code)