### PR TITLE
fix: restrict GITHUB_TOKEN to read-only permissions in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [master]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Adds `permissions: contents: read` at the workflow level in `.github/workflows/ci.yml`
- Resolves [CodeQL alert #2](https://github.com/bushidocodes/dynamic-programming-katas/security/code-scanning/2): missing explicit permissions block on the `GITHUB_TOKEN`
- The CI job only checks out code and runs Maven tests, so `contents: read` is the minimal required permission

## Test plan

- [ ] CI passes on this PR
- [ ] CodeQL alert #2 is dismissed after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)